### PR TITLE
Remove rails version

### DIFF
--- a/lti2.gemspec
+++ b/lti2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
 
-  s.add_dependency 'rails', '~> 4.1.1'
+  s.add_dependency 'rails'
 
   # lti2 commons
   s.add_runtime_dependency 'oauth', '~> 0.4.7'

--- a/lti2_tc/app/controllers/lti2_tc/tools_controller.rb
+++ b/lti2_tc/app/controllers/lti2_tc/tools_controller.rb
@@ -76,6 +76,8 @@ module Lti2Tc
 
       resource_nodes = tool_proxy_wrapper.first_at('tool_profile.resource_handler')
 
+      # TODO: Move this resource creation code to LTI2_tc_sample_app
+      
       # course 2(SMPL101), 11 & 12 DEP from conformance test
       target_courses = [2, 5, 6]
       for resource_node in resource_nodes

--- a/lti2_tc/lti2_tc.gemspec
+++ b/lti2_tc/lti2_tc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.0.0'
 
-  s.add_dependency 'rails', '~> 4.1.1'
+  s.add_dependency 'rails'
   s.add_dependency 'mysql2', '~> 0.3.13'
 
   s.add_development_dependency 'sqlite3'

--- a/lti2_tp/lti2_tp.gemspec
+++ b/lti2_tp/lti2_tp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '~> 2.0.0'
 
-  s.add_dependency 'rails', '~> 4.1.1'
+  s.add_dependency 'rails'
   s.add_dependency 'mysql2', '~> 0.3.13'
 
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
This pulls in the commits from the origin that removed the rails version. It does appear to include some other items as well though. Are these additional changes a blocker? If so we can just extract out the rails version changes as our own commit.